### PR TITLE
Use MediaRecorder API and WebAudio API to record instead

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,44 +178,65 @@
         },
         mounted() {
           const that = this
-          
+
           this.recorder = {
             start: async () => {
-              const stream = await navigator.mediaDevices
-                .getUserMedia({
-                  audio: {
-                    autoGainControl: false,
-                    echoCancellation: false,
-                    noiseSuppression: true
-                  },
-                  video: false
-                })
+              const audioCtx =
+                window.mainAudioContext ||
+                (window.mainAudioContext = new (window.AudioContext ||
+                  window.webkitAudioContext)())
+              const stream = await navigator.mediaDevices.getUserMedia({
+                audio: {
+                  autoGainControl: false,
+                  echoCancellation: false,
+                  noiseSuppression: true
+                },
+                video: false
+              })
               const recorder = new MediaRecorder(stream, {
                 mimeType: 'audio/webm; codecs="pcm"'
               })
+              const source = audioCtx.createMediaStreamSource(stream)
+              const processor = audioCtx.createScriptProcessor(0, 1, 1)
+              processor.onaudioprocess = e => {
+                const data = e.inputBuffer.getChannelData(0)
+                let amplitude = 0
+                for (let i = 0; i < data.length; i++) {
+                  const a = Math.abs(data[i])
+                  if (a > amplitude) amplitude = a
+                }
+                that.amplitude = amplitude
+              }
+              source.connect(processor)
+              processor.connect(audioCtx.destination)
+
               const blobs = []
               recorder.ondataavailable = function(e) {
                 blobs.push(e.data)
                 console.log(e.data.size)
               }
-              const finishPromise = new Promise(r => recorder.onstop = r)
+              const finishPromise = new Promise(r => (recorder.onstop = r))
               recorder.start()
               this.recorder.stop = () => {
                 recorder.stop()
+                for (const track of stream.getTracks()) track.stop()
                 return {
                   getMp3: async () => {
                     await finishPromise
-                    const audioCtx = new (window.AudioContext || window.webkitAudioContext)()
+                    const audioCtx = new (window.AudioContext ||
+                      window.webkitAudioContext)()
                     const buffer = await new Blob(blobs).arrayBuffer()
                     console.log(buffer)
                     const audioBuffer = await audioCtx.decodeAudioData(buffer)
                     const waveBuffer = audioBufferToWav(audioBuffer)
-                    const file = new File([waveBuffer], 'recording.wav', {type: 'audio/wav'})
+                    const file = new File([waveBuffer], 'recording.wav', {
+                      type: 'audio/wav'
+                    })
                     return [[waveBuffer], file]
                   }
                 }
               }
-            },
+            }
           }
 
           // Demo mode: Add a pre-recorded file
@@ -275,7 +296,7 @@
     </style>
 
     <script src="vendor/audiobuffer-to-wav.js"></script>
-    
+
     <!-- ############################################################### -->
 
     <!-- Load the Vue dependency -->

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
                 @dragstart="onDragStart($event, r)"
                 draggable
                 style="margin-right: 1em; cursor: move;"
-                ><waveform :data="r.waveform" @click="waveformClick()"></waveform></span
+                ><waveform :data="r.waveform"></waveform></span
               >
               <audio style="margin-left: auto; flex: none;" :src="r.url" controls></audio>
               <a

--- a/index.html
+++ b/index.html
@@ -117,12 +117,13 @@
     </script>
     <style>
       .waveform {
-        display: flex;
+        display: inline-flex;
         align-items: flex-end;
         justify-content: flex-start;
         height: 64px;
         padding: 1px;
         padding-left: 0px;
+        border: 2px solid #8b8685;
       }
       .waveform > div {
         background: #8b8685;
@@ -222,7 +223,9 @@
               })
               const source = audioCtx.createMediaStreamSource(stream)
               const processor = audioCtx.createScriptProcessor(0, 1, 1)
-              this.currentWaveform = []
+              const waveform = []
+              const startTime = Date.now()
+              this.currentWaveform = waveform
               processor.onaudioprocess = e => {
                 const data = e.inputBuffer.getChannelData(0)
                 let amplitude = 0
@@ -231,17 +234,18 @@
                   if (a > amplitude) amplitude = a
                 }
                 that.amplitude = amplitude
-                i
-                if (!this.currentWaveform.nextId) {
-                  this.currentWaveform.nextId = 1
+                if (!waveform.nextId) {
+                  waveform.nextId = 1
                 }
-                if (!this.currentWaveform || Date.now() - this.currentWaveform[this.currentWaveform.length - 1].time > 150) {
-                  this.currentWaveform.push({
-                    id: this.currentWaveform.nextId++,
+                if (!waveform.length || Date.now() - waveform[waveform.length - 1].time > 200) {
+                  waveform.push({
+                    id: waveform.nextId++,
                     height: Math.round(amplitude * 100),
+                    time: Date.now(),
+                    audioTime: Date.now() - startTime,
                   })
                 } else {
-                  const column = this.currentWaveform[this.currentWaveform.length - 1]
+                  const column = waveform[waveform.length - 1]
                   column.height = Math.max(column.height, Math.round(amplitude * 100))
                 }
               }

--- a/index.html
+++ b/index.html
@@ -240,8 +240,9 @@
                   const a = Math.abs(data[i])
                   if (a > amplitude) amplitude = a
                 }
-                that.amplitude = amplitude
-                const audioTime = now() - startTime
+                that.amplitude = Math.max(this.amplitude - (now - lastTime) / 500, 0, amplitude)
+                lastTime = now
+                const audioTime = now - startTime
                 if (audioTime - waveform[waveform.length - 1].time > 200) {
                   waveform.push({
                     id: waveform.nextId++,

--- a/index.html
+++ b/index.html
@@ -175,13 +175,13 @@
                 :href="r.url"
                 @dragstart="onDragStart($event, r)"
                 draggable
-                style="margin-right: 1em; cursor: move;"
-                >🎙</span
+                style="margin-right: 1em; cursor: move; flex: auto;"
+                ><waveform :data="r.waveform"></waveform></span
               >
-              <audio :src="r.url" controls></audio>
+              <audio style="flex: none;" :src="r.url" controls></audio>
               <a
                 href="#"
-                style="margin-left: 1em; text-decoration: none;"
+                style="margin-left: 1em; text-decoration: none; flex: none;"
                 @click="$event.preventDefault(); recordings.splice(index, 1)"
                 >❌</a
               >
@@ -321,14 +321,27 @@
                 file.name = 'demo.mp3'
                 const arrayBuffer = await file.arrayBuffer()
                 const ctx = new OfflineAudioContext(1, 1, 44100)
-                const audioBuffer = ctx.decodeAudioData(arrayBuffer)
-                      const pcm = audioBuffer.getChannelData(0)
-                      const bucketSize = audioBuffer.sampleRate * 0.2
-                      const buckets = Array(Math.ceil(pcm.length / bucketSize)).fill(0)
-                      for (let i = 0; i < pcm.length; i++) {
-                      }
+                const audioBuffer = await ctx.decodeAudioData(arrayBuffer)
+                const pcm = audioBuffer.getChannelData(0)
+                const bucketSize = audioBuffer.sampleRate * 0.2
+                const buckets = Array(Math.ceil(pcm.length / bucketSize)).fill(
+                  0
+                )
+                for (let i = 0; i < pcm.length; i++) {
+                  const bucketNumber = Math.floor(i / bucketSize)
+                  buckets[bucketNumber] = Math.max(
+                    buckets[bucketNumber],
+                    Math.abs(pcm[i])
+                  )
+                }
+                const max = Math.max(...buckets)
+                const waveform = buckets.map((v, i) => ({
+                  id: i,
+                  height: Math.round(v / max * 90),
+                  time: i * 200,
+                }))
                 const url = URL.createObjectURL(file)
-                this.recordings.unshift({ file, url, id: nextId++ })
+                this.recordings.unshift({ file, url, id: nextId++, waveform })
               })
               .catch(e => {
                 alert('Demo start failed: ' + e)
@@ -347,13 +360,14 @@
               if (!this.activeRecording) {
                 this.activeRecording = await this.recorder.start()
               } else {
+                const { waveform } = this.activeRecording
                 const stoppedRecording = this.activeRecording.stop()
                 const file = await stoppedRecording.getFile(
                   'recording' + new Date().toJSON().replace(/\W/g, '') + '.wav'
                 )
                 const url = URL.createObjectURL(file)
                 this.activeRecording = null
-                this.recordings.unshift({ file, url, id: nextId++ })
+                this.recordings.unshift({ file, url, id: nextId++, waveform })
               }
             } catch (e) {
               console.error(e)

--- a/index.html
+++ b/index.html
@@ -223,7 +223,12 @@
               })
               const source = audioCtx.createMediaStreamSource(stream)
               const processor = audioCtx.createScriptProcessor(0, 1, 1)
-              const waveform = []
+              const waveform = [{
+                id: 0,
+                height: 0,
+                time: 0
+              }]
+              let nextWaveformColumnId = 1
               const startTime = Date.now()
               this.currentWaveform = waveform
               processor.onaudioprocess = e => {
@@ -234,15 +239,12 @@
                   if (a > amplitude) amplitude = a
                 }
                 that.amplitude = amplitude
-                if (!waveform.nextId) {
-                  waveform.nextId = 1
-                }
-                if (!waveform.length || Date.now() - waveform[waveform.length - 1].time > 200) {
+                const audioTime = Date.now() - startTime
+                if (audioTime - waveform[waveform.length - 1].time > 200) {
                   waveform.push({
                     id: waveform.nextId++,
                     height: Math.round(amplitude * 100),
-                    time: Date.now(),
-                    audioTime: Date.now() - startTime,
+                    time: waveform[waveform.length - 1].time + 200,
                   })
                 } else {
                   const column = waveform[waveform.length - 1]

--- a/index.html
+++ b/index.html
@@ -29,7 +29,8 @@
         color: #8b8685;
         line-height: 1;
       }
-      h1, h2 {
+      h1,
+      h2 {
         margin-bottom: 0;
       }
       h1 + p {
@@ -38,7 +39,8 @@
       a {
         color: #ffa;
       }
-      h1 + p, h1 + p a {
+      h1 + p,
+      h1 + p a {
         color: #8b8685;
       }
       .btn {
@@ -131,8 +133,14 @@
           style="position: relative;"
           :class="{ 'is-recording': recording }"
         >
-          <span style="position: absolute; top: 0; left: 0; bottom: 0; background: #8b8685;" :style="{ width: (amplitude * 100).toFixed(1) + '%' }" v-if="recording"></span>
-          <span style="position: relative; display: inline-block;">{{ recording ? 'Stop' : 'Record' }}</span>
+          <span
+            style="position: absolute; top: 0; left: 0; bottom: 0; background: #8b8685;"
+            :style="{ width: (amplitude * 100).toFixed(1) + '%' }"
+            v-if="recording"
+          ></span>
+          <span style="position: relative; display: inline-block;"
+            >{{ recording ? 'Stop' : 'Record' }}</span
+          >
         </button>
         <section class="mt-4">
           <h2>
@@ -184,41 +192,36 @@
         },
         mounted() {
           const that = this
-
-          this.recorder = new MicRecorder({ bitRate: 320 })
-
-          // Monkey patch MicRecorder with ability to display waveform
-          this.recorder.addMicrophoneListener = (addMicrophoneListener => function(stream) {
-            addMicrophoneListener.call(this, stream)
-            this.processor.addEventListener('audioprocess', e => {
-              const data = e.inputBuffer.getChannelData(0)
-              let amplitude = 0
-              for (let i = 0; i < data.length; i++) {
-                const a = Math.abs(data[i])
-                if (a > amplitude) amplitude = a
-              }
-              that.amplitude = amplitude
-            })
-          })(this.recorder.addMicrophoneListener)
           
-          // Monkey patch WebRTC to force-disable auto gain control
-          navigator.mediaDevices.getUserMedia = (getUserMedia => function(...args) {
-            const [options] = args
-            if (options.audio) {
-              if (options.audio === true) {
-                options.audio = {}
+          this.recorder = {
+            start: async () => {
+              const stream = await navigator.mediaDevices
+                .getUserMedia({
+                  audio: {
+                    autoGainControl: false,
+                    echoCancellation: false,
+                    noiseSuppression: true
+                  },
+                  video: false
+                })
+              const recorder = new MediaRecorder(stream, {
+                mimeType: 'audio/webm; codecs="opus"'
+              })
+              recorder.ondataavailable = function(e) {
+                console.log(e)
               }
-              options.audio.autoGainControl = false
-              options.audio.echoCancellation = false
-              options.audio.noiseSuppression = true
-            }
-            return getUserMedia.call(this, ...args)
-            //          autoGainControl
-          })(navigator.mediaDevices.getUserMedia)
+              recorder.start()
+              this.recorder.stop = () => {
+                recorder.stop()
+              }
+            },
+          }
 
           // Demo mode: Add a pre-recorded file
           if (location.search === '?demo') {
-            fetch('https://cdn.glitch.com/d2fe94e5-8121-48fa-87d8-5c1a7793c56c%2Fdemo.mp3?v=1584020680220&cors')
+            fetch(
+              'https://cdn.glitch.com/d2fe94e5-8121-48fa-87d8-5c1a7793c56c%2Fdemo.mp3?v=1584020680220&cors'
+            )
               .then(r => r.blob())
               .then(file => {
                 file.name = 'demo.mp3'
@@ -275,7 +278,6 @@
     <!-- Load the Vue dependency -->
     <script src="https://unpkg.com/vue@2.6.10/dist/vue.js"></script>
     <script src="https://unpkg.com/vue-router@3.1.3/dist/vue-router.js"></script>
-    <script src="https://unpkg.com/mic-recorder-to-mp3@2.2.1/dist/index.min.js"></script>
 
     <!-- Start the runtime -->
     <script>

--- a/index.html
+++ b/index.html
@@ -231,7 +231,9 @@
               let nextWaveformColumnId = 1
               const startTime = Date.now()
               this.currentWaveform = waveform
+              let lastTime = Date.now()
               processor.onaudioprocess = e => {
+                const now = Date.now()
                 const data = e.inputBuffer.getChannelData(0)
                 let amplitude = 0
                 for (let i = 0; i < data.length; i++) {
@@ -239,7 +241,7 @@
                   if (a > amplitude) amplitude = a
                 }
                 that.amplitude = amplitude
-                const audioTime = Date.now() - startTime
+                const audioTime = now() - startTime
                 if (audioTime - waveform[waveform.length - 1].time > 200) {
                   waveform.push({
                     id: waveform.nextId++,

--- a/index.html
+++ b/index.html
@@ -33,15 +33,8 @@
       h2 {
         margin-bottom: 0;
       }
-      h1 + p {
-        margin-top: 0.25em;
-      }
       a {
         color: #ffa;
-      }
-      h1 + p,
-      h1 + p a {
-        color: #8b8685;
       }
       .btn {
         display: block;
@@ -64,13 +57,6 @@
     <!-- Application shell with loading indicator -->
     <div id="main" class="p-4">
       <h1 class="text-lg">Dead simple voice recorder</h1>
-      <p>
-        A simple voice recording app using the
-        <a href="https://github.com/closeio/mic-recorder-to-mp3"
-          >mic-recorder-to-mp3</a
-        >
-        library.
-      </p>
 
       <!-- Loading indicator -->
       <div v-if="false">
@@ -220,12 +206,12 @@
                   getMp3: async () => {
                     await finishPromise
                     const audioCtx = new (window.AudioContext || window.webkitAudioContext)()
-                    const blob = new Blob(blobs, { type: 'audio/webm; codecs="pcm"' })
-                    const buffer = await blob.arrayBuffer()
+                    const buffer = await new Blob(blobs).arrayBuffer()
                     console.log(buffer)
-                    const data = await audioCtx.decodeAudioData(buffer)
-                    console.log(data)
-                    return [blobs, blob]
+                    const audioBuffer = await audioCtx.decodeAudioData(buffer)
+                    const waveBuffer = audioBufferToWav(audioBuffer)
+                    const file = new File([waveBuffer], 'recording.wav', {type: 'audio/wav'})
+                    return [[waveBuffer], file]
                   }
                 }
               }
@@ -262,7 +248,7 @@
                 this.recording = false
                 const file = new File(
                   buffer,
-                  'recording' + new Date().toJSON().replace(/\W/g, '') + '.mp3',
+                  'recording' + new Date().toJSON().replace(/\W/g, '') + '.wav',
                   {
                     type: blob.type,
                     lastModified: Date.now()
@@ -288,6 +274,8 @@
       }
     </style>
 
+    <script src="vendor/audiobuffer-to-wav.js"></script>
+    
     <!-- ############################################################### -->
 
     <!-- Load the Vue dependency -->

--- a/index.html
+++ b/index.html
@@ -105,6 +105,34 @@
 
     <!-- ############################################################### -->
 
+    <template id="waveform-component">
+      <div class="waveform">
+        <div v-for="column of data" :style="{ height: column.height + '%' }"></div>
+      </div>
+    </template>
+    <script>
+      App.registerComponent('waveform', {
+        props: ['data']
+      })
+    </script>
+    <style>
+      .waveform {
+        display: flex;
+        align-items: flex-end;
+        justify-content: flex-start;
+        height: 64px;
+        padding: 1px;
+        padding-left: 0px;
+      }
+      .waveform > div {
+        background: #8b8685;
+        margin-left: 1px;
+        width: 4px;
+      }
+    </style>
+
+    <!-- ############################################################### -->
+
     <template id="home-route">
       <div>
         <button
@@ -122,6 +150,7 @@
             >{{ recording ? 'Stop' : 'Record' }}</span
           >
         </button>
+        <waveform v-if="currentWaveform" :data="currentWaveform"></waveform>
         <section class="mt-4">
           <h2>
             Recorded stuffs
@@ -167,6 +196,7 @@
           return {
             recording: false,
             recordings: [],
+            currentWaveform: null,
             amplitude: 0
           }
         },
@@ -192,6 +222,7 @@
               })
               const source = audioCtx.createMediaStreamSource(stream)
               const processor = audioCtx.createScriptProcessor(0, 1, 1)
+              this.currentWaveform = []
               processor.onaudioprocess = e => {
                 const data = e.inputBuffer.getChannelData(0)
                 let amplitude = 0
@@ -200,6 +231,19 @@
                   if (a > amplitude) amplitude = a
                 }
                 that.amplitude = amplitude
+                i
+                if (!this.currentWaveform.nextId) {
+                  this.currentWaveform.nextId = 1
+                }
+                if (!this.currentWaveform || Date.now() - this.currentWaveform[this.currentWaveform.length - 1].time > 150) {
+                  this.currentWaveform.push({
+                    id: this.currentWaveform.nextId++,
+                    height: Math.round(amplitude * 100),
+                  })
+                } else {
+                  const column = this.currentWaveform[this.currentWaveform.length - 1]
+                  column.height = Math.max(column.height, Math.round(amplitude * 100))
+                }
               }
               source.connect(processor)
               processor.connect(audioCtx.destination)
@@ -207,7 +251,6 @@
               const blobs = []
               recorder.ondataavailable = function(e) {
                 blobs.push(e.data)
-                console.log(e.data.size)
               }
               const finishPromise = new Promise(r => (recorder.onstop = r))
               recorder.start()

--- a/index.html
+++ b/index.html
@@ -107,7 +107,10 @@
 
     <template id="waveform-component">
       <div class="waveform">
-        <div v-for="column of data" :style="{ height: column.height + '%' }"></div>
+        <div
+          v-for="column of data"
+          :style="{ height: column.height + '%' }"
+        ></div>
       </div>
     </template>
     <script>
@@ -145,17 +148,23 @@
           <span
             style="position: absolute; top: 0; left: 0; bottom: 0; background: #8b8685;"
             :style="{ width: (amplitude * 100).toFixed(1) + '%' }"
-            v-if="recording"
+            v-if="activeRecording"
           ></span>
           <span style="position: relative; display: inline-block;"
             >{{ recording ? 'Stop' : 'Record' }}</span
           >
         </button>
-        <waveform v-if="currentWaveform" :data="currentWaveform"></waveform>
-        <section class="mt-4">
-          <h2>
-            Recorded stuffs
-          </h2>
+        <template v-if="!recordings.length && !activeRecording">
+          <p style="color: #bef; text-align: center;">
+            <em>&uarr; Click the Record button above to begin</em>
+          </p>
+        </template>
+        <template v-if="activeRecording">
+          <div style="margin-top: 1em">
+            <waveform :data="activeRecording.waveform"></waveform>
+          </div>
+        </template>
+        <section v-if="recordings.length">
           <div>
             <p
               v-for="(r, index) of recordings"
@@ -178,9 +187,6 @@
               >
             </p>
           </div>
-          <p v-if="!recordings.length" style="color: #bef;">
-            <em>Your recordings will appear here.</em>
-          </p>
           <p style="color: #8b8685">
             <em
               >You can drag recordings out into your folder (Google Chrome
@@ -195,9 +201,8 @@
       App.registerRoute('home', '/', {
         data() {
           return {
-            recording: false,
+            activeRecording: null,
             recordings: [],
-            currentWaveform: null,
             amplitude: 0
           }
         },
@@ -223,14 +228,15 @@
               })
               const source = audioCtx.createMediaStreamSource(stream)
               const processor = audioCtx.createScriptProcessor(0, 1, 1)
-              const waveform = [{
-                id: 0,
-                height: 0,
-                time: 0
-              }]
+              const waveform = [
+                {
+                  id: 0,
+                  height: 0,
+                  time: 0
+                }
+              ]
               let nextWaveformColumnId = 1
               const startTime = Date.now()
-              this.currentWaveform = waveform
               let lastTime = Date.now()
               processor.onaudioprocess = e => {
                 const now = Date.now()
@@ -240,18 +246,25 @@
                   const a = Math.abs(data[i])
                   if (a > amplitude) amplitude = a
                 }
-                that.amplitude = Math.max(this.amplitude - (now - lastTime) / 500, 0, amplitude)
+                that.amplitude = Math.max(
+                  this.amplitude - (now - lastTime) / 500,
+                  0,
+                  amplitude
+                )
                 lastTime = now
                 const audioTime = now - startTime
                 if (audioTime - waveform[waveform.length - 1].time > 200) {
                   waveform.push({
                     id: waveform.nextId++,
                     height: Math.round(amplitude * 100),
-                    time: waveform[waveform.length - 1].time + 200,
+                    time: waveform[waveform.length - 1].time + 200
                   })
                 } else {
                   const column = waveform[waveform.length - 1]
-                  column.height = Math.max(column.height, Math.round(amplitude * 100))
+                  column.height = Math.max(
+                    column.height,
+                    Math.round(amplitude * 100)
+                  )
                 }
               }
               source.connect(processor)
@@ -261,26 +274,31 @@
               recorder.ondataavailable = function(e) {
                 blobs.push(e.data)
               }
+
               const finishPromise = new Promise(r => (recorder.onstop = r))
               recorder.start()
-              this.recorder.stop = () => {
-                recorder.stop()
-                for (const track of stream.getTracks()) track.stop()
-                source.disconnect()
-                processor.disconnect()
-                return {
-                  getMp3: async filename => {
-                    await finishPromise
-                    const audioCtx = new (window.AudioContext ||
-                      window.webkitAudioContext)()
-                    const buffer = await new Blob(blobs).arrayBuffer()
-                    const audioBuffer = await audioCtx.decodeAudioData(buffer)
-                    const waveBuffer = audioBufferToWav(audioBuffer)
-                    const file = new File([waveBuffer], filename, {
-                      type: 'audio/wav',
-                      lastModified: Date.now()
-                    })
-                    return file
+
+              return {
+                waveform,
+                stop: () => {
+                  recorder.stop()
+                  for (const track of stream.getTracks()) track.stop()
+                  source.disconnect()
+                  processor.disconnect()
+                  return {
+                    getFile: async filename => {
+                      await finishPromise
+                      const audioCtx = new (window.AudioContext ||
+                        window.webkitAudioContext)()
+                      const buffer = await new Blob(blobs).arrayBuffer()
+                      const audioBuffer = await audioCtx.decodeAudioData(buffer)
+                      const waveBuffer = audioBufferToWav(audioBuffer)
+                      const file = new File([waveBuffer], filename, {
+                        type: 'audio/wav',
+                        lastModified: Date.now()
+                      })
+                      return file
+                    }
                   }
                 }
               }
@@ -309,19 +327,15 @@
           },
           async toggle() {
             try {
-              if (!this.recording) {
-                await this.recorder.start()
-                this.recording = true
+              if (!this.activeRecording) {
+                this.activeRecording = await this.recorder.start()
               } else {
-                const file = await this.recorder
-                  .stop()
-                  .getMp3(
-                    'recording' +
-                      new Date().toJSON().replace(/\W/g, '') +
-                      '.wav'
-                  )
-                this.recording = false
+                const stoppedRecording = this.activeRecording.stop()
+                const file = await stoppedRecording.getFile(
+                  'recording' + new Date().toJSON().replace(/\W/g, '') + '.wav'
+                )
                 const url = URL.createObjectURL(file)
+                this.activeRecording = null
                 this.recordings.unshift({ file, url, id: nextId++ })
               }
             } catch (e) {

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
           @click="toggle"
           class="btn"
           style="position: relative;"
-          :class="{ 'is-recording': recording }"
+          :class="{ 'is-recording': !!activeRecording }"
         >
           <span
             style="position: absolute; top: 0; left: 0; bottom: 0; background: #8b8685;"
@@ -151,7 +151,7 @@
             v-if="activeRecording"
           ></span>
           <span style="position: relative; display: inline-block;"
-            >{{ recording ? 'Stop' : 'Record' }}</span
+            >{{ activeRecording ? 'Stop' : 'Record' }}</span
           >
         </button>
         <template v-if="!recordings.length && !activeRecording">
@@ -236,9 +236,15 @@
                 }
               ]
               let nextWaveformColumnId = 1
-              const startTime = Date.now()
+              let startTime = 0
               let lastTime = Date.now()
               processor.onaudioprocess = e => {
+                if (recorder.state !== 'recording') {
+                  return
+                }
+                if (!startTime) {
+                  startTime = Date.now()
+                }
                 const now = Date.now()
                 const data = e.inputBuffer.getChannelData(0)
                 let amplitude = 0
@@ -311,10 +317,21 @@
               'https://cdn.glitch.com/d2fe94e5-8121-48fa-87d8-5c1a7793c56c%2Fdemo.mp3?v=1584020680220&cors'
             )
               .then(r => r.blob())
-              .then(file => {
+              .then(async file => {
                 file.name = 'demo.mp3'
+                const arrayBuffer = await file.arrayBuffer()
+                const ctx = new OfflineAudioContext(1, 1, 44100)
+                const audioBuffer = ctx.decodeAudioData(arrayBuffer)
+                      const pcm = audioBuffer.getChannelData(0)
+                      const bucketSize = audioBuffer.sampleRate * 0.2
+                      const buckets = Array(Math.ceil(pcm.length / bucketSize)).fill(0)
+                      for (let i = 0; i < pcm.length; i++) {
+                      }
                 const url = URL.createObjectURL(file)
                 this.recordings.unshift({ file, url, id: nextId++ })
+              })
+              .catch(e => {
+                alert('Demo start failed: ' + e)
               })
           }
         },

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
     </script>
     <style>
       .waveform {
-        display: inline-flex;
+        display: flex;
         align-items: flex-end;
         justify-content: flex-start;
         height: 64px;
@@ -175,10 +175,10 @@
                 :href="r.url"
                 @dragstart="onDragStart($event, r)"
                 draggable
-                style="margin-right: 1em; cursor: move; flex: auto;"
-                ><waveform :data="r.waveform"></waveform></span
+                style="margin-right: 1em; cursor: move;"
+                ><waveform :data="r.waveform" @click="waveformClick()"></waveform></span
               >
-              <audio style="flex: none;" :src="r.url" controls></audio>
+              <audio style="margin-left: auto; flex: none;" :src="r.url" controls></audio>
               <a
                 href="#"
                 style="margin-left: 1em; text-decoration: none; flex: none;"

--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
         color: #8b8685;
         line-height: 1;
       }
-      h1,
       h2 {
         margin-bottom: 0;
       }
@@ -44,6 +43,7 @@
         background: #d7fc70;
         border: 2px solid #d7fc70;
         color: #000;
+        padding: 10px;
       }
       .btn.is-recording {
         background: #353433;
@@ -107,12 +107,6 @@
 
     <template id="home-route">
       <div>
-        <p>
-          <textarea
-            style="width: 100%; box-sizing: border-box; font: inherit; background: #252423; border: 1px solid #454443; color: #bef;"
-            placeholder="Scratchpad (You can write anything in here... just for convenience, you know)"
-          ></textarea>
-        </p>
         <button
           @click="toggle"
           class="btn"
@@ -220,19 +214,21 @@
               this.recorder.stop = () => {
                 recorder.stop()
                 for (const track of stream.getTracks()) track.stop()
+                source.disconnect()
+                processor.disconnect()
                 return {
-                  getMp3: async () => {
+                  getMp3: async filename => {
                     await finishPromise
                     const audioCtx = new (window.AudioContext ||
                       window.webkitAudioContext)()
                     const buffer = await new Blob(blobs).arrayBuffer()
-                    console.log(buffer)
                     const audioBuffer = await audioCtx.decodeAudioData(buffer)
                     const waveBuffer = audioBufferToWav(audioBuffer)
-                    const file = new File([waveBuffer], 'recording.wav', {
-                      type: 'audio/wav'
+                    const file = new File([waveBuffer], filename, {
+                      type: 'audio/wav',
+                      lastModified: Date.now()
                     })
-                    return [[waveBuffer], file]
+                    return file
                   }
                 }
               }
@@ -265,16 +261,14 @@
                 await this.recorder.start()
                 this.recording = true
               } else {
-                const [buffer, blob] = await this.recorder.stop().getMp3()
+                const file = await this.recorder
+                  .stop()
+                  .getMp3(
+                    'recording' +
+                      new Date().toJSON().replace(/\W/g, '') +
+                      '.wav'
+                  )
                 this.recording = false
-                const file = new File(
-                  buffer,
-                  'recording' + new Date().toJSON().replace(/\W/g, '') + '.wav',
-                  {
-                    type: blob.type,
-                    lastModified: Date.now()
-                  }
-                )
                 const url = URL.createObjectURL(file)
                 this.recordings.unshift({ file, url, id: nextId++ })
               }
@@ -286,14 +280,6 @@
         }
       })
     </script>
-    <style>
-      /* GitHub’s README API renders header with `a.anchor` link.
-       * It does not work with Vue Router and so is hidden.
-       * This is just to show the functionality of vuetoy; feel free to remove it when you implement your app. */
-      .markdown-content a.anchor {
-        display: none;
-      }
-    </style>
 
     <script src="vendor/audiobuffer-to-wav.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -205,14 +205,29 @@
                   video: false
                 })
               const recorder = new MediaRecorder(stream, {
-                mimeType: 'audio/webm; codecs="opus"'
+                mimeType: 'audio/webm; codecs="pcm"'
               })
+              const blobs = []
               recorder.ondataavailable = function(e) {
-                console.log(e)
+                blobs.push(e.data)
+                console.log(e.data.size)
               }
+              const finishPromise = new Promise(r => recorder.onstop = r)
               recorder.start()
               this.recorder.stop = () => {
                 recorder.stop()
+                return {
+                  getMp3: async () => {
+                    await finishPromise
+                    const audioCtx = new (window.AudioContext || window.webkitAudioContext)()
+                    const blob = new Blob(blobs, { type: 'audio/webm; codecs="pcm"' })
+                    const buffer = await blob.arrayBuffer()
+                    console.log(buffer)
+                    const data = await audioCtx.decodeAudioData(buffer)
+                    console.log(data)
+                    return [blobs, blob]
+                  }
+                }
               }
             },
           }

--- a/vendor/audiobuffer-to-wav.js
+++ b/vendor/audiobuffer-to-wav.js
@@ -1,0 +1,98 @@
+// From https://unpkg.com/audiobuffer-to-wav@1.0.0/index.js
+// MIT Licensed
+
+var audioBufferToWav = (() => {
+  return function audioBufferToWav (buffer, opt) {
+    opt = opt || {}
+
+    var numChannels = buffer.numberOfChannels
+    var sampleRate = buffer.sampleRate
+    var format = opt.float32 ? 3 : 1
+    var bitDepth = format === 3 ? 32 : 16
+
+    var result
+    if (numChannels === 2) {
+      result = interleave(buffer.getChannelData(0), buffer.getChannelData(1))
+    } else {
+      result = buffer.getChannelData(0)
+    }
+
+    return encodeWAV(result, format, sampleRate, numChannels, bitDepth)
+  }
+
+  function encodeWAV (samples, format, sampleRate, numChannels, bitDepth) {
+    var bytesPerSample = bitDepth / 8
+    var blockAlign = numChannels * bytesPerSample
+
+    var buffer = new ArrayBuffer(44 + samples.length * bytesPerSample)
+    var view = new DataView(buffer)
+
+    /* RIFF identifier */
+    writeString(view, 0, 'RIFF')
+    /* RIFF chunk length */
+    view.setUint32(4, 36 + samples.length * bytesPerSample, true)
+    /* RIFF type */
+    writeString(view, 8, 'WAVE')
+    /* format chunk identifier */
+    writeString(view, 12, 'fmt ')
+    /* format chunk length */
+    view.setUint32(16, 16, true)
+    /* sample format (raw) */
+    view.setUint16(20, format, true)
+    /* channel count */
+    view.setUint16(22, numChannels, true)
+    /* sample rate */
+    view.setUint32(24, sampleRate, true)
+    /* byte rate (sample rate * block align) */
+    view.setUint32(28, sampleRate * blockAlign, true)
+    /* block align (channel count * bytes per sample) */
+    view.setUint16(32, blockAlign, true)
+    /* bits per sample */
+    view.setUint16(34, bitDepth, true)
+    /* data chunk identifier */
+    writeString(view, 36, 'data')
+    /* data chunk length */
+    view.setUint32(40, samples.length * bytesPerSample, true)
+    if (format === 1) { // Raw PCM
+      floatTo16BitPCM(view, 44, samples)
+    } else {
+      writeFloat32(view, 44, samples)
+    }
+
+    return buffer
+  }
+
+  function interleave (inputL, inputR) {
+    var length = inputL.length + inputR.length
+    var result = new Float32Array(length)
+
+    var index = 0
+    var inputIndex = 0
+
+    while (index < length) {
+      result[index++] = inputL[inputIndex]
+      result[index++] = inputR[inputIndex]
+      inputIndex++
+    }
+    return result
+  }
+
+  function writeFloat32 (output, offset, input) {
+    for (var i = 0; i < input.length; i++, offset += 4) {
+      output.setFloat32(offset, input[i], true)
+    }
+  }
+
+  function floatTo16BitPCM (output, offset, input) {
+    for (var i = 0; i < input.length; i++, offset += 2) {
+      var s = Math.max(-1, Math.min(1, input[i]))
+      output.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7FFF, true)
+    }
+  }
+
+  function writeString (view, offset, string) {
+    for (var i = 0; i < string.length; i++) {
+      view.setUint8(offset + i, string.charCodeAt(i))
+    }
+  }
+})()


### PR DESCRIPTION
## Problem

The `mic-recorder-to-mp3` uses a `ScriptProcessorNode` to send the audio data to the LAME MP3 encoder. While this works well most of the time, sometimes pauses in the app causes skips in the recording.

Now we have `MediaRecorder` API that can record a MediaStream. However it only outputs a webm file (e.g. `audio/webm`), and we cannot just use the result with Apple tools such as Final Cut Pro or iMovie.

However we can use the Web Audio API to decode this webm file into an AudioBuffer and encode this AudioBuffer into a wav file. This is possible thanks to the `audiobuffer-to-wav` package.